### PR TITLE
Fix cost summary agent tool list

### DIFF
--- a/costguard/sub_agents/cost_summary/agent.py
+++ b/costguard/sub_agents/cost_summary/agent.py
@@ -13,10 +13,8 @@ cost_summary_agent = Agent(
     model=MODEL,
     name="cost_summary_agent",
     instruction=prompt.COST_SUMMARY_PROMPT,
-
     tools=[
         bigquery_utils.get_cost_summary,
-        bigquery_utils.get_total_spend,
         bigquery_utils.get_total_spend,
         bigquery_utils.get_high_cost_projects,
         bigquery_utils.get_cost_by_region,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,4 +1,3 @@
-
 """Test cases for the CostGuard Agent."""
 
 import textwrap
@@ -6,7 +5,7 @@ import dotenv
 import pytest
 from google.adk.runners import InMemoryRunner
 from google.genai.types import Part, UserContent
-from ...costguard.agent import root_agent
+from costguard.agent import root_agent
 
 pytest_plugins = ("pytest_asyncio",)
 


### PR DESCRIPTION
## Summary
- remove duplicated cost summary tool
- fix root agent import in unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'costguard' / 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687b3759ca54832ab23ad0e218c217cd